### PR TITLE
IPv6 and TCP support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,6 @@ Non-interactive usage:
 
 ::
 
-    certbot --non-interactive --agree-tos --email certmaster@example.com certonly --preferred-challenges dns --authenticator certbot-dns-standalone:dns-standalone --certbot-dns-standalone:dns-standalone-address=0.0.0.0 --certbot-dns-standalone:dns-standalone-port=53 -d example.com
+    certbot --non-interactive --agree-tos --email certmaster@example.com certonly --preferred-challenges dns --authenticator certbot-dns-standalone:dns-standalone --certbot-dns-standalone:dns-standalone-address=0.0.0.0 --certbot-dns-standalone:dns-standalone-ipv6-address=:: --certbot-dns-standalone:dns-standalone-port=53 -d example.com
 
 To renew the certificates add ``certbot renew`` to ``crontab``.


### PR DESCRIPTION
Added IPv6 support. It's disabled by default (mostly so people don't end up with accidentally having something listen on `::`), but easily turned on by specifying the `ipv6-address` option. (Should fix #8.)

Also added TCP support. I don't actually remember what I used that for, but either way it's here. (If you feel TCP support isn't really useful, let me know - I can just strip the commit from the PR).