### PR TITLE
Update Docker to better reuse certbot and autobuild

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,42 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ["master"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
-FROM debian:bookworm-20221219-slim
+FROM certbot/certbot
 
-RUN apt-get -y update
-RUN apt-get -y install certbot python3-certbot-dns-standalone
-RUN apt-get clean
+EXPOSE 53
 
-EXPOSE 80 443 53
+COPY . /opt/certbot/src/standalone-dns
 
-ENTRYPOINT [ "certbot" ]
-
-VOLUME /etc/letsencrypt /var/lib/letsencrypt
-
-WORKDIR /opt/certbot
+RUN python tools/pip_install.py --no-cache-dir --editable /opt/certbot/src/standalone-dns

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,17 @@ Debian
 
     # apt-get install certbot python3-certbot-dns-standalone
 
+Docker
+------
+
+::
+
+    docker run -it --rm --name certbot \
+      -v "/etc/letsencrypt:/etc/letsencrypt" \
+      -v "/var/lib/letsencrypt:/var/lib/letsencrypt" \
+      -p 53:53 \
+      ghcr.io/siilike/certbot-dns-standalone:master certonly
+
 Usage
 =====
 
@@ -120,7 +131,7 @@ First, build the certbot image:
 
     docker build -t certbot /path/to/certbot-dns-standalone/
 
-Next, the certificate:
+Next, run certbot:
 
 ::
 


### PR DESCRIPTION
This updates the current Dockerfile to use the upstream `certbot/certbot` image directly and just install the plugin into it, rather than fetching from (potentially outdated) apt.

This also adds a GitHub action which will automatically build and publish the docker image in GitHub packages, too, which makes it really easy for people to use the container without any local build/setup!

You can see how the [action](https://github.com/ncovercash/certbot-dns-standalone/actions/runs/6553362890) and [package](https://github.com/ncovercash/certbot-dns-standalone/pkgs/container/certbot-dns-standalone) looks over at my repo.