### PR TITLE
use new "unittest.mock" from standard library

### DIFF
--- a/certbot_dns_standalone/dns_standalone_test.py
+++ b/certbot_dns_standalone/dns_standalone_test.py
@@ -2,8 +2,7 @@
 
 import os
 import unittest
-
-import mock
+from unittest import mock
 
 from certbot import errors
 from certbot.plugins import dns_test_common

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_requires = [
     'acme>=0.21.1',
     'certbot>=2.1.0',
     'dnslib>=0.9.0',
-    'mock',
     'setuptools',
 ]
 


### PR DESCRIPTION
https://github.com/testing-cabal/mock

> mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.