### PR TITLE
Changed setup.py to accept younger reptiles than 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 with open('README.rst') as file:
     long_description = file.read()
 
-version = '1.1'
+version = '1.2'
 
 # Remember to update local-oldest-requirements.txt when changing the minimum
 # acme/certbot version.
@@ -28,7 +28,7 @@ setup(
     url='https://github.com/siilike/certbot-dns-standalone',
     author="Lauri Keel",
     license='Apache License 2.0',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.12', #, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Plugins',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,16 +4,16 @@ summary: Standalone DNS Authenticator plugin for Certbot
 description: Standalone DNS Authenticator plugin for Certbot
 confinement: strict
 grade: stable
-base: core20
-adopt-info: certbot-dns-standalone
+base: core24
+adopt-info: .
 
 parts:
-  certbot-dns-standalone:
+  .:
     plugin: python
     source: .
     override-pull: |
-        snapcraftctl pull
-        snapcraftctl set-version `grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]"`
+        craftctl default
+        craftctl set version=$(grep ^version $SNAPCRAFT_PART_SRC/setup.py | cut -f2 -d= | tr -d "'[:space:]")
     build-environment:
       # We set this environment variable while building to try and increase the
       # stability of fetching the rust crates needed to build the cryptography
@@ -41,7 +41,7 @@ parts:
     source: .
     stage: [setup.py, certbot-shared]
     override-pull: |
-        snapcraftctl pull
+        craftctl default
         mkdir -p $SNAPCRAFT_PART_SRC/certbot-shared
 
 slots:
@@ -49,7 +49,7 @@ slots:
     interface: content
     content: certbot-1
     read:
-      - $SNAP/lib/python3.8/site-packages
+      - $SNAP/lib/python3.12/site-packages
 
 plugs:
   certbot-metadata:


### PR DESCRIPTION
Alates detsembri algusest ei toimi certbot-dns-standalone enam: [Impacts to Third Party Plugins](https://github.com/siilike/certbot-dns-standalone/issues/26). Ainus muudatus oli v2lja kommenteerida >3 pyytoni keeld.